### PR TITLE
fix init-root panic

### DIFF
--- a/cmd/ocfl/run/init_root.go
+++ b/cmd/ocfl/run/init_root.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -22,6 +23,9 @@ func (cmd *initRootCmd) Run(ctx context.Context, fsysConfig string, stdout io.Wr
 	fsys, dir, err := parseLocation(ctx, fsysConfig, logger, getenv)
 	if err != nil {
 		return err
+	}
+	if fsys == nil {
+		return errors.New("location for new storage root is required")
 	}
 	spec := ocfl.Spec(cmd.Spec)
 	reg := extension.DefaultRegister()

--- a/cmd/ocfl/run/run.go
+++ b/cmd/ocfl/run/run.go
@@ -127,6 +127,7 @@ func CLI(ctx context.Context, args []string, stdout, stderr io.Writer, getenv fu
 		logger.Error(err.Error())
 		return err
 	}
+	// fsys is nil if rootConfig is empty
 	fsys, dir, err := parseLocation(ctx, rootConifg, logger, getenv)
 	if err != nil {
 		logger.Error("parsing OCFL root path: " + err.Error())

--- a/cmd/ocfl/run/run_test.go
+++ b/cmd/ocfl/run/run_test.go
@@ -36,6 +36,16 @@ func runCLI(args []string, env map[string]string, expect func(err error, stdout,
 	expect(err, stdout.String(), stderr.String())
 }
 
+func TestInitRoot(t *testing.T) {
+	t.Run("root not set", func(t *testing.T) {
+		// should return an error
+		args := []string{"init-root"}
+		runCLI(args, nil, func(err error, stdout string, stderr string) {
+			be.True(t, err != nil)
+		})
+	})
+}
+
 func TestAllLayouts(t *testing.T) {
 	testLayout := func(t *testing.T, root string, layout string) {
 		env := map[string]string{"OCFL_ROOT": root}


### PR DESCRIPTION
Fix init-root so it doesn't panic if `root` isn't set.
Closes #8.