### PR TITLE
stage commit uses OCFL_USER_NAME and OCFL_USER_NAME env vars

### DIFF
--- a/cmd/ocfl/run/stage.go
+++ b/cmd/ocfl/run/stage.go
@@ -191,14 +191,32 @@ func (cmd *StageCommitCmd) Run(g *globals) error {
 	if err != nil {
 		return err
 	}
+	if cmd.Message == "" {
+		return fmt.Errorf("a message is required for the new object version")
+	}
+	userName := cmd.Name
+	if userName == "" {
+		userName = g.getenv(envVarUserName)
+	}
+	if userName == "" {
+		return fmt.Errorf("a name is required for the new object version")
+	}
+	userEmail := cmd.Email
+	if userEmail == "" {
+		userEmail = g.getenv(envVarUserEmail)
+	}
+	if userEmail != "" {
+		// make address a valid uri
+		userEmail = "email:" + userEmail
+	}
 	commit, err := stage.buildCommit()
 	if err != nil {
 		return fmt.Errorf("stage has errors: %w", err)
 	}
 	commit.Message = cmd.Message
 	commit.User = ocfl.User{
-		Name:    cmd.Name,
-		Address: cmd.Email,
+		Name:    userName,
+		Address: userEmail,
 	}
 	if err := obj.Commit(ctx, commit); err != nil {
 		return fmt.Errorf("creating new object version: %w", err)

--- a/cmd/ocfl/run/stage_test.go
+++ b/cmd/ocfl/run/stage_test.go
@@ -153,7 +153,7 @@ func TestStageCommit(t *testing.T) {
 		be.NilErr(t, err)
 	})
 	// v1 stage
-	cmd := []string{"stage", "new", "--file", stagePath, "--ocflv", "1.0", "--alg", "sha256", objID}
+	cmd := []string{"stage", "new", "--file", stagePath, "--ocflv", "1.0", "--alg", "sha512", objID}
 	testutil.RunCLI(cmd, env, func(err error, stdout, stderr string) {
 		be.NilErr(t, err)
 		be.In(t, stagePath, stderr)
@@ -192,4 +192,12 @@ func TestStageCommit(t *testing.T) {
 		be.In(t, "email:"+email, stdout)
 		be.In(t, name, stdout)
 	})
+	// object has not validation errors or warnings
+	cmd = []string{"validate", "--id", objID}
+	testutil.RunCLI(cmd, env, func(err error, stdout, stderr string) {
+		be.NilErr(t, err)
+		be.Zero(t, stdout)
+		be.Zero(t, stderr)
+	})
+
 }


### PR DESCRIPTION
- `stage commit` commands uses `OCFL_USER_NAME` and `OCFL_USER_NAME` environment vars, if set
- if the email address is set, `email:` prefix is added to the make the user address field a valid URI -- helps avoid validation warnings later.