### PR TITLE
add env variable to disable request checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ export AWS_ACCESS_KEY_ID="..."
 export AWS_SECRET_ACCESS_KEY="..."
 ```
 
-[Path-style S3 requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) are enabled by setting `OCFL_S3_PATHSTYLE=true`.
+[Path-style S3 requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) can be enabled by setting `OCFL_S3_PATHSTYLE=true`.
+
+Some non-AWS S3 implementations may return errors due to recent API changes (see
+https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you are seeing errors
+like "`api error XAmzContentSHA256Mismatch: UnknownError`", try disabling
+request checksums `OCFL_S3_CHECKSUM_WHEN_REQUIRED=true`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ export AWS_SECRET_ACCESS_KEY="..."
 [Path-style S3 requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) can be enabled by setting `OCFL_S3_PATHSTYLE=true`.
 
 Some non-AWS S3 implementations may return errors due to [API
-changes](https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you see
-"`api error XAmzContentSHA256Mismatch: UnknownError`", try disabling request
-checksums `OCFL_S3_CHECKSUM_WHEN_REQUIRED=true`.
+changes](https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you see the
+error, "`XAmzContentSHA256Mismatch`", try disabling request checksums using:
+`OCFL_S3_CHECKSUM_WHEN_REQUIRED=true`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Flags:
 Commands:
   commit          Create or update an object using contents of a local directory
   diff            Show changed files between versions of an object
+  delete          Delete an object in the storage root
   export          Export object contents to the local filesystem
   info            Show information about an object or the active storage root
   init-root       Create a new OCFL storage root
@@ -61,10 +62,10 @@ export AWS_SECRET_ACCESS_KEY="..."
 
 [Path-style S3 requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) can be enabled by setting `OCFL_S3_PATHSTYLE=true`.
 
-Some non-AWS S3 implementations may return errors due to recent API changes (see
-https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you are seeing errors
-like "`api error XAmzContentSHA256Mismatch: UnknownError`", try disabling
-request checksums `OCFL_S3_CHECKSUM_WHEN_REQUIRED=true`.
+Some non-AWS S3 implementations may return errors due to [API
+changes](https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you see
+"`api error XAmzContentSHA256Mismatch: UnknownError`", try disabling request
+checksums `OCFL_S3_CHECKSUM_WHEN_REQUIRED=true`.
 
 ## Installation
 

--- a/cmd/ocfl/run/run.go
+++ b/cmd/ocfl/run/run.go
@@ -29,6 +29,12 @@ const (
 	envVarUserEmail   = "OCFL_USER_EMAIL"   // user email for commit
 	envVarS3PathStyle = "OCFL_S3_PATHSTYLE" // if "true", enable path-style addressing for s3
 
+	// if "true", S3 request checksums are only calculated when required. This
+	// is sometimes needed to support non-AWS S3 implementations like
+	// OpenStack's Object Storage. See:
+	// https://github.com/aws/aws-sdk-go-v2/discussions/2960
+	envVarS3ChecksumWhenRequired = "OCFL_S3_CHECKSUM_WHEN_REQUIRED"
+
 	// keys that can be used in tests
 	envVarAWSKey      = "AWS_ACCESS_KEY_ID"
 	envVarAWSSecret   = "AWS_SECRET_ACCESS_KEY"
@@ -149,6 +155,9 @@ func (g *globals) parseLocation(loc string) (ocfl.WriteFS, string, error) {
 		}
 		if envRegion != "" {
 			loadOpts = append(loadOpts, config.WithRegion(envRegion))
+		}
+		if strings.EqualFold(g.getenv(envVarS3ChecksumWhenRequired), "true") {
+			loadOpts = append(loadOpts, config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired))
 		}
 		cfg, err := config.LoadDefaultConfig(g.ctx, loadOpts...)
 		if err != nil {


### PR DESCRIPTION
Add a new environment variable configuration (`OCFL_S3_CHECKSUM_WHEN_REQUIRED`) that disables request integrity checks that can break on non-AWS S3 implementations. This fixes #45.