### PR TITLE
option to use md5 for s3 requests that require checksums

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       OCFL_TEST_S3: "http://minio:9000"
 
   minio:
-    image: quay.io/minio/minio:RELEASE.2024-09-22T00-33-43Z
+    image: quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z
     restart: unless-stopped
     volumes:
       - minio-data:/data

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ export AWS_SECRET_ACCESS_KEY="..."
 
 [Path-style S3 requests](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access) can be enabled by setting `OCFL_S3_PATHSTYLE=true`.
 
-Some non-AWS S3 implementations may return errors due to [API
-changes](https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you see the
-error, "`XAmzContentSHA256Mismatch`", try disabling request checksums using:
-`OCFL_S3_CHECKSUM_WHEN_REQUIRED=true`.
+Some non-AWS S3 implementations may return errors due to [changes in the AWS
+SDK](https://github.com/aws/aws-sdk-go-v2/discussions/2960). If you see an error
+like "`XAmzContentSHA256Mismatch`", try using MD5 (instead of CRC32) for S3
+requests that require checksums: `OCFL_S3_MD5_CHECKSUMS=true`.
 
 ## Installation
 

--- a/cmd/ocfl/internal/testutil/runcli.go
+++ b/cmd/ocfl/internal/testutil/runcli.go
@@ -25,6 +25,7 @@ func RunCLIInput(args []string, env map[string]string, input string, expect func
 	if S3Enabled() {
 		env["AWS_ENDPOINT_URL"] = S3Endpoint()
 		env["OCFL_S3_PATHSTYLE"] = "true"
+		//env["OCFL_S3_MD5_CHECKSUMS"] = "true"
 	}
 	err := run.CLI(ctx, args, stdin, stdout, stderr, getenv)
 	expect(err, stdout.String(), stderr.String())


### PR DESCRIPTION
This changes the configuration used to support older-S3 implementations that don't support the new CRC32-based request integrity algorithms: `OCFL_S3_CHECKSUM_WHEN_REQUIRED` is replaced with `OCFL_S3_MD5_CHECKSUMS`. 

Fixes #45 (again)