### PR TITLE
delete: add --not-object flag

### DIFF
--- a/cmd/ocfl/run/delete.go
+++ b/cmd/ocfl/run/delete.go
@@ -3,6 +3,7 @@ package run
 import (
 	"bufio"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/srerickson/ocfl-go"
@@ -14,6 +15,7 @@ const deleteHelp = "Delete an object in the storage root"
 type DeleteCmd struct {
 	ID        string `name:"id" short:"i" help:"The ID for the object to delete" required:""`
 	NoConfirm bool   `name:"yes" short:"y" help:"skip delete confirmation."`
+	NotObject bool   `name:"not-object" help:"skip check that files for ID are those of an OCFL object."`
 }
 
 func (cmd *DeleteCmd) Run(g *globals) error {
@@ -21,12 +23,23 @@ func (cmd *DeleteCmd) Run(g *globals) error {
 	if err != nil {
 		return err
 	}
-	obj, err := root.NewObject(g.ctx, cmd.ID, ocfl.ObjectMustExist())
-	if err != nil {
-		return fmt.Errorf("reading object id: %q: %w", cmd.ID, err)
+	var deletePath string // path in root.FS() we will delete
+	switch {
+	case cmd.NotObject:
+		objPath, err := root.ResolveID(cmd.ID)
+		if err != nil {
+			return fmt.Errorf("cannot delete %q: %w", cmd.ID, err)
+		}
+		deletePath = path.Join(root.Path(), objPath)
+	default:
+		obj, err := root.NewObject(g.ctx, cmd.ID, ocfl.ObjectMustExist())
+		if err != nil {
+			return fmt.Errorf("cannot delete %q: %w", cmd.ID, err)
+		}
+		deletePath = obj.Path()
 	}
 	if !cmd.NoConfirm {
-		fmt.Fprintf(g.stdout, "do you really want to delete %q [y/N]: ", obj.ID())
+		fmt.Fprintf(g.stdout, "do you really want to delete all files for %q? [y/N]: ", cmd.ID)
 		reader := bufio.NewReader(g.stdin)
 		line, err := reader.ReadString('\n')
 		response := strings.ToLower(strings.Trim(line, " \n"))
@@ -35,9 +48,9 @@ func (cmd *DeleteCmd) Run(g *globals) error {
 			return nil
 		}
 	}
-	if err := ocflfs.RemoveAll(g.ctx, obj.FS(), obj.Path()); err != nil {
-		return fmt.Errorf("deleting %q: %w", obj.ID(), err)
+	if err := ocflfs.RemoveAll(g.ctx, root.FS(), deletePath); err != nil {
+		return fmt.Errorf("deleting %q: %w", cmd.ID, err)
 	}
-	g.logger.Info("deleted object", "object_id", obj.ID(), "object_path", obj.Path())
+	g.logger.Info("deleted object", "object_id", cmd.ID, "object_path", deletePath)
 	return nil
 }

--- a/cmd/ocfl/run/delete_test.go
+++ b/cmd/ocfl/run/delete_test.go
@@ -1,11 +1,16 @@
 package run_test
 
 import (
+	"context"
 	"errors"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/carlmjohnson/be"
+	"github.com/srerickson/ocfl-go"
+	ocflfs "github.com/srerickson/ocfl-go/fs"
 	"github.com/srerickson/ocfl-tools/cmd/ocfl/internal/testutil"
 )
 
@@ -28,6 +33,47 @@ func TestDelete(t *testing.T) {
 		args = []string{`delete`, `--id`, "ark:123/abc"}
 		testutil.RunCLIInput(args, env, "y\n", func(err error, stdout string, stderr string) {
 			be.NilErr(t, err)
+			be.In(t, "deleted object", stderr)
+		})
+
+		// object is deleted
+		args = []string{`ls`, `--id`, "ark:123/abc"}
+		testutil.RunCLI(args, env, func(err error, stdout string, stderr string) {
+			be.Nonzero(t, err)
+			be.True(t, errors.Is(err, fs.ErrNotExist))
+		})
+	})
+
+	t.Run("delete partial object", func(t *testing.T) {
+		ctx := context.Background()
+		id := "ark:123/abc"
+		_, fixtures := testutil.TempDirTestData(t,
+			`testdata/store-fixtures/1.0/good-stores/reg-extension-dir-root`,
+		)
+		ocflRoot := fixtures[0]
+		root, err := ocfl.NewRoot(ctx, ocflfs.DirFS(ocflRoot), ".")
+		be.NilErr(t, err)
+
+		// delete the object's inventory file.
+		objPath, err := root.ResolveID(id)
+		be.NilErr(t, err)
+
+		err = os.Remove(filepath.Join(ocflRoot, filepath.FromSlash(objPath), `inventory.json`))
+		be.NilErr(t, err)
+
+		// delete without --not-object fails
+		env := map[string]string{"OCFL_ROOT": ocflRoot}
+		args := []string{`delete`, `--id`, id, `--yes`}
+		testutil.RunCLIInput(args, env, "", func(err error, stdout string, stderr string) {
+			be.Nonzero(t, err)
+			be.In(t, "no such file or directory", stderr)
+		})
+
+		// delete with --not-object works
+		args = []string{`delete`, `--id`, id, `--not-object`, `--yes`}
+		testutil.RunCLIInput(args, env, "", func(err error, stdout string, stderr string) {
+			be.NilErr(t, err)
+			be.In(t, "deleted object", stderr)
 		})
 
 		// object is deleted


### PR DESCRIPTION
Adds `--not-object` flag for `delete` command that skips checking that files for the ID are those of an OCFL object. This is useful for cleaning up broken ocfl objects in a storage root.