### PR TITLE
cleanup `ocfl stage new`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,12 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"dockerComposeFile": "docker-compose.yml",
     "service": "devcontainer",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+  	"features": {
+    	"ghcr.io/devcontainers/features/node:1": {
+      		"version": "lts"
+   	 	}
+  	},
+  	"postCreateCommand": "npm install -g @anthropic-ai/claude-code"
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .tool-versions
+.claude
 cmd/ocfl/ocfl
 dist/
 ocfl

--- a/cmd/ocfl/internal/stage/stagefile.go
+++ b/cmd/ocfl/internal/stage/stagefile.go
@@ -56,9 +56,7 @@ type StageFile struct {
 }
 
 // NewStageFile creates a new stage for the object. The newAlg argument can be used
-// to set non-standard digest algorithm if the object does not exist. newID is
-// for the id on an object if it doesn't exist (The ocfl-go Object api should
-// really support this, but not yet: https://github.com/srerickson/ocfl-go/issues/114)
+// to set non-standard digest algorithm if the object does not exist.
 func NewStageFile(obj *ocfl.Object, newAlg string) (*StageFile, error) {
 	objID := obj.ID()
 	if objID == "" {

--- a/cmd/ocfl/run/stage.go
+++ b/cmd/ocfl/run/stage.go
@@ -40,9 +40,8 @@ type stageCmdBase struct {
 // stage new
 type NewStageCmd struct {
 	stageCmdBase
-	Spec string `name:"ocflv" default:"1.1" help:"OCFL spec for the new object version"`
-	Alg  string `name:"alg" default:"sha512" help:"Digest Algorithm used to digest content. Ignored for existing objects."`
-	ID   string `name:"id" arg:"" help:"object id for the new stage"`
+	Alg string `name:"alg" default:"sha512" help:"Digest Algorithm used to digest content. Ignored for existing objects."`
+	ID  string `name:"id" short:"i" required:"" help:"object id for the new stage"`
 }
 
 func (cmd *NewStageCmd) Run(g *globals) error {


### PR DESCRIPTION
- the object id is given with a required `--id` flag, rather than a positional argument, for consitency.
- remove unused 'ocflv' flag.
- a few additional tests

Parts of this were generated with assistance from claude code. I'm experimenting.